### PR TITLE
PostgreSQL でもインストールできるように修正しました

### DIFF
--- a/xoops_trust_path/modules/xupdate/admin/class/installer/XupdateInstallUtils.class.php
+++ b/xoops_trust_path/modules/xupdate/admin/class/installer/XupdateInstallUtils.class.php
@@ -406,7 +406,7 @@ class Xupdate_InstallUtils
         if($autoLink)
         {
             $sql = sprintf(
-                'insert into `%s` set (`block_id`,`module_id`) values (%d,0);',
+                'insert into %s (block_id,module_id) values (%d,0);',
                 $blockHandler->db->prefix('block_module_link'),
                 $blockObj->getVar('bid')
             );

--- a/xoops_trust_path/modules/xupdate/admin/class/installer/XupdateUninstaller.class.php
+++ b/xoops_trust_path/modules/xupdate/admin/class/installer/XupdateUninstaller.class.php
@@ -103,7 +103,11 @@ class Xupdate_Uninstaller
                     array(XOOPS_DB_PREFIX,$dirname),
                     $table
                 );
-                $sql = sprintf('drop table `%s`;',$tableName);
+                if(XOOPS_DB_TYPE == "pdo_pgsql") {
+                    $sql = sprintf('drop table "%s";',$tableName);
+                } else {
+                    $sql = sprintf('drop table `%s`;',$tableName);
+                }
                 
                 if($db->query($sql))
                 {

--- a/xoops_trust_path/modules/xupdate/admin/class/installer/XupdateUpdater.class.php
+++ b/xoops_trust_path/modules/xupdate/admin/class/installer/XupdateUpdater.class.php
@@ -44,9 +44,9 @@ class Xupdate_Updater
     	$db =& $root->mController->getDB();
     	$table = $db->prefix($this->_mCurrentXoopsModule->get('dirname') . '_modulestore');
     	 
-    	$sql = 'SELECT `isactive` FROM '.$table ;
+    	$sql = 'SELECT isactive FROM '.$table ;
     	if(! $db->query($sql)) {
-    		$sql = 'ALTER TABLE `'.$table.'` ADD `isactive` int(11) NOT NULL DEFAULT \'-1\'';
+    		$sql = 'ALTER TABLE '.$table.' ADD isactive int(11) NOT NULL DEFAULT \'-1\'';
     		if ($db->query($sql)) {
     			$this->mLog->addReport('Success updated '.$table.' - ADD isactive');
     		} else {
@@ -54,9 +54,9 @@ class Xupdate_Updater
     		}
     	}
     	 
-    	$sql = 'SELECT `hasupdate` FROM '.$table ;
+    	$sql = 'SELECT hasupdate FROM '.$table ;
     	if(! $db->query($sql)) {
-    		$sql = 'ALTER TABLE `'.$table.'` ADD `hasupdate` tinyint(1) NOT NULL DEFAULT \'0\'';
+    		$sql = 'ALTER TABLE '.$table.' ADD hasupdate tinyint(1) NOT NULL DEFAULT \'0\'';
     		if ($db->query($sql)) {
     			$this->mLog->addReport('Success updated '.$table.' - ADD hasupdate');
     		} else {
@@ -82,15 +82,15 @@ class Xupdate_Updater
     	$db =& $root->mController->getDB();
     	$table = $db->prefix($this->_mCurrentXoopsModule->get('dirname') . '_modulestore');
     
-    	$sql = 'SELECT `contents` FROM '.$table ;
+    	$sql = 'SELECT contents FROM '.$table ;
     	if(! $db->query($sql)) {
-    		$sql = 'ALTER TABLE `'.$table.'` ADD `contents` varchar(255) NOT NULL default \'\'';
+    		$sql = 'ALTER TABLE '.$table.' ADD contents varchar(255) NOT NULL default \'\'';
     		if ($db->query($sql)) {
     			$this->mLog->addReport('Success updated '.$table.' - ADD contents');
     		} else {
     			$this->mLog->addError('Error update '.$table.' - ADD contents');
     		}
-    		$sql = 'ALTER TABLE `'.$table.'` ADD INDEX ( `contents` )';
+    		$sql = 'ALTER TABLE '.$table.' ADD INDEX ( contents )';
     		if ($db->query($sql)) {
     			$this->mLog->addReport('Success updated '.$table.' - ADD Index contents');
     		} else {
@@ -116,13 +116,13 @@ class Xupdate_Updater
     	$db =& $root->mController->getDB();
     	$table = $db->prefix($this->_mCurrentXoopsModule->get('dirname') . '_modulestore');
     
-   		$sql = 'ALTER TABLE `'.$table.'` CHANGE `dirname` `dirname` varchar(255) NOT NULL default \'\'';
+   		$sql = 'ALTER TABLE '.$table.' CHANGE dirname dirname varchar(255) NOT NULL default \'\'';
     	if ($db->query($sql)) {
     		$this->mLog->addReport('Success updated '.$table.' - `dirname` VARCHAR( 255 )');
     	} else {
     		$this->mLog->addError('Error update '.$table.' - `dirname` VARCHAR( 255 )');
     	}
-    	$sql = 'ALTER TABLE `'.$table.'` CHANGE `trust_dirname` `trust_dirname` varchar(255) default \'\'';
+    	$sql = 'ALTER TABLE '.$table.' CHANGE trust_dirname trust_dirname varchar(255) default \'\'';
     	if ($db->query($sql)) {
     		$this->mLog->addReport('Success updated '.$table.' - `trust_dirname` VARCHAR( 255 )');
     	} else {

--- a/xoops_trust_path/modules/xupdate/class/handler/ModuleStore.class.php
+++ b/xoops_trust_path/modules/xupdate/class/handler/ModuleStore.class.php
@@ -17,7 +17,11 @@ class Xupdate_ModuleStore extends Legacy_AbstractObject {
 
 	public function __construct()
 	{
-		$this->initVar('id', XOBJ_DTYPE_INT, '0', false);//Primary key
+        if(XOOPS_DB_TYPE == "pdo_pgsql"){
+    		$this->initVar('id', XOBJ_DTYPE_INT, "nextval('".XOOPS_DB_PREFIX."_".$this->mDirname."_modulestore_id_seq')", false);//Primary key
+        }else {
+    		$this->initVar('id', XOBJ_DTYPE_INT, '0', false);//Primary key
+        }
 		$this->initVar('sid', XOBJ_DTYPE_INT, '0', false);//store join
 
 		$this->initVar('dirname', XOBJ_DTYPE_STRING, '', false);

--- a/xoops_trust_path/modules/xupdate/sql/pdo_pgsql.sql
+++ b/xoops_trust_path/modules/xupdate/sql/pdo_pgsql.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "{prefix}_{dirname}_store" (
+	"sid" serial,
+	"name" varchar(255) NOT NULL default '',
+	"contents" varchar(255) NOT NULL default '',
+	"addon_url" varchar(255) NOT NULL default '',
+	"setting_type" int NOT NULL default 0,
+	"reg_unixtime" int NOT NULL default 0,
+PRIMARY KEY  ("sid"));
+
+CREATE TABLE "{prefix}_{dirname}_modulestore" (
+	"id" serial,
+	"sid" int NOT NULL default 0,
+	"dirname" varchar(255) NOT NULL default '',
+	"trust_dirname" varchar(255) default '',
+	"version" smallint default '100',
+	"license" varchar(255) NOT NULL default '',
+	"required" varchar(255) NOT NULL default '',
+	"last_update" int default '0',
+	"target_key" varchar(255) NOT NULL default '',
+	"target_type" varchar(255) NOT NULL default '',
+	"replicatable" smallint NOT NULL default '0',
+	"description" varchar(255) NOT NULL default '',
+	"unzipdirlevel" smallint NOT NULL default '0',
+	"addon_url" varchar(255) NOT NULL default '',
+	"detail_url" varchar(255) NOT NULL default '',
+	"options" text,
+	"isactive" int NOT NULL DEFAULT '-1',
+	"hasupdate" smallint NOT NULL DEFAULT '0',
+	"contents" varchar(255) NOT NULL default '',
+PRIMARY KEY  ("id")
+ );
+CREATE INDEX {prefix}_{dirname}_modulestore_sid_idx ON {prefix}_{dirname}_modulestore (sid);
+CREATE INDEX {prefix}_{dirname}_modulestore_dirname_idx ON {prefix}_{dirname}_modulestore (dirname);
+

--- a/xoops_trust_path/modules/xupdate/xoops_version.php
+++ b/xoops_trust_path/modules/xupdate/xoops_version.php
@@ -55,6 +55,7 @@ $modversion['legacy_installer'] = array(
 $modversion['disable_legacy_2nd_installer'] = false;
 
 $modversion['sqlfile']['mysql'] = 'sql/mysql.sql';
+$modversion['sqlfile']['pdo_pgsql'] = 'sql/pdo_pgsql.sql';
 $modversion['tables'] = array(
 //	  '{prefix}_{dirname}_xxxx',
 ##[cubson:tables]


### PR DESCRIPTION
legacy モジュールで postgresql 対応のものがインストールされているのが前提です。
ほとんどの修正が「`」を除去しただけです。
sql/pdo_pgsql.sql を追加してあります。
