### PR TITLE
Protector mainfile: enable protector check in mainfile.php

### DIFF
--- a/xoops_trust_path/modules/xupdate/class/AbstractAction.class.php
+++ b/xoops_trust_path/modules/xupdate/class/AbstractAction.class.php
@@ -287,6 +287,10 @@ EOD;
     protected function _removeInstallDir() {
     	$ret = false;
     	if ($this->Ftp->app_login()) {
+    		// enable protector in mainfile.php
+    		$this->Func->write_mainfile_protector();
+    		
+    		// write protect mainfile.php
     		if ($main_perm = @ fileperms(XOOPS_ROOT_PATH . '/mainfile.php')) {
     			$main_perm = substr(sprintf('%o', $main_perm), -3);
     			$set_perm = '';

--- a/xoops_trust_path/modules/xupdate/class/AbstractAction.class.php
+++ b/xoops_trust_path/modules/xupdate/class/AbstractAction.class.php
@@ -309,6 +309,12 @@ EOD;
     			$this->Ftp->localChmod($this->Xupdate->params['is_writable']['path'], 0707);
     		}
     		
+    		// set writable protector config dir
+    		$protector_config = XOOPS_TRUST_PATH . '/modules/protector/configs';
+    		if (! Xupdate_Utils::checkDirWritable($protector_config)) {
+    			$this->Ftp->localChmod($protector_config, 0707);
+    		}
+    		
     		clearstatcache();
     		
     		// edit /preload/CorePackPreload.class.php

--- a/xoops_trust_path/modules/xupdate/class/Func.class.php
+++ b/xoops_trust_path/modules/xupdate/class/Func.class.php
@@ -357,7 +357,27 @@ class Xupdate_Func {
 		$this->Ftp->appendMes('<span style="color:red;">'.$msg.'</span><br />');
 		$this->content.= '<span style="color:red;">'.$msg.'</span><br />';
 	}
-
+	
+	public function write_mainfile_protector($do_chmod = false) {
+		$mailfile = XOOPS_ROOT_PATH . '/mainfile.php';
+		$src = file_get_contents($mailfile);
+		if (! preg_match('#(?:include|require)\s*\(?\s*XOOPS_TRUST_PATH\s*.\s*[\'|"]/modules/protector/include/precheck.inc.php\'#i', $src)) {
+			$src = str_replace('if (!defined(\'_LEGACY_PREVENT_LOAD_CORE_\') && XOOPS_ROOT_PATH != \'\') {', 'if (!defined(\'_LEGACY_PREVENT_LOAD_CORE_\') && XOOPS_ROOT_PATH != \'\') {
+        include XOOPS_TRUST_PATH.\'/modules/protector/include/precheck.inc.php\' ;', $src);
+			$src = preg_replace('#include XOOPS_ROOT_PATH.\'/include/common.php\';\s+}#', 'include XOOPS_ROOT_PATH.\'/include/common.php\';
+        }
+        include XOOPS_TRUST_PATH.\'/modules/protector/include/postcheck.inc.php\' ;', $src);
+			if ($do_chmod) {
+				$mod = @ fileperms($mailfile);
+				$this->Ftp->localChmod($mailfile, 0606);
+			}
+			file_put_contents($mailfile, $src, LOCK_EX);
+			if ($do_chmod) {
+				$this->Ftp->localChmod($mailfile, $mod? $mod : 0404);
+			}
+		}
+		return true;
+	}
 } // end class
 } // end if
 

--- a/xoops_trust_path/modules/xupdate/class/Func.class.php
+++ b/xoops_trust_path/modules/xupdate/class/Func.class.php
@@ -358,6 +358,12 @@ class Xupdate_Func {
 		$this->content.= '<span style="color:red;">'.$msg.'</span><br />';
 	}
 	
+	/**
+	 * enable protector of mainfile.php
+	 * 
+	 * @param boolean $do_chmod
+	 * @return boolean
+	 */
 	public function write_mainfile_protector($do_chmod = false) {
 		$mailfile = XOOPS_ROOT_PATH . '/mainfile.php';
 		$src = file_get_contents($mailfile);

--- a/xoops_trust_path/modules/xupdate/include/FtpModuleInstall.class.php
+++ b/xoops_trust_path/modules/xupdate/include/FtpModuleInstall.class.php
@@ -305,12 +305,18 @@ class Xupdate_FtpModuleInstall extends Xupdate_FtpCommonZipArchive {
 						}
 					}
 				}
+				
 				// for protector 'manip_value' update
 				if (XC_CLASS_EXISTS('Protector')) {
 					$db =& Database::getInstance();
 					$protector =& Protector::getInstance();
 					$protector->setConn($db->conn);
 					$protector->updateConfIntoDb('manip_value' , '');
+				} else {
+					// check and enable protector in mainfile.php
+					if (file_exists(XOOPS_TRUST_PATH . '/modules/protector/include/precheck.inc.php')) {
+						$this->Func->write_mainfile_protector(true);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Protector を有効にするためのコードが mainfile.php に追記されていない場合は、XCL のインストール時、または legacy のアップデート時に maifile.php へ有効化コードを追記する機能の実装。
