### PR TITLE
extra language support (XoopsX/xupdate#47)

### DIFF
--- a/xoops_trust_path/modules/xupdate/class/Ftp.class.php
+++ b/xoops_trust_path/modules/xupdate/class/Ftp.class.php
@@ -118,7 +118,7 @@ class Xupdate_Ftp extends Xupdate_Ftp_ {
 
 	public function uploadNakami($sourcePath, $targetPath)
 	{
-		$this->mes .= " start FTP put (normal mode) ".htmlspecialchars($targetPath ,ENT_QUOTES ,_CHARSET)." ..<br>\n";
+		$this->mes .= " start FTP put (normal mode) form `".htmlspecialchars(substr($sourcePath, strlen($this->exploredDirPath) + 1) ,ENT_QUOTES ,_CHARSET)."` to `".htmlspecialchars($targetPath ,ENT_QUOTES ,_CHARSET)."` ..<br>\n";
 		$result = $this->_ftpPutNakami($sourcePath, $targetPath);
 		return $result;
 	}

--- a/xoops_trust_path/modules/xupdate/class/ftp/Abstract.class.php
+++ b/xoops_trust_path/modules/xupdate/class/ftp/Abstract.class.php
@@ -21,6 +21,7 @@ class Xupdate_Ftp_Abstract {
 	protected $Verbose;
 	protected $OS_local;
 	protected $OS_remote;
+	public $exploredDirPath;
 
 	/* Private variables */
 	protected $_lastaction;


### PR DESCRIPTION
Will check next dirs in archive.

legacy: `/extras/extra_languages/<LANG>/html`
          or
        `/extras/extra_languages/<LANG>`

Others: `extras/html/modules/language/<LANG>`
          and
        `extras/xoops_trust_path/modules/language/<LANG>`
